### PR TITLE
Add patches to fix SPI DMA (enabling FPGA bitfile transfer).

### DIFF
--- a/0031-spi-imx-move-wml-setting-to-later-than-setup_transfe.patch
+++ b/0031-spi-imx-move-wml-setting-to-later-than-setup_transfe.patch
@@ -1,0 +1,98 @@
+From 59b2d126cd5a69cb0554b82b8f1c3afc4871597c Mon Sep 17 00:00:00 2001
+From: Robin Gong <yibin.gong@nxp.com>
+Date: Wed, 10 Oct 2018 10:32:42 +0000
+Subject: [PATCH 1/5] spi: imx: move wml setting to later than setup_transfer
+
+Current dynamic burst length is based on the whole transfer length,
+that's ok if there is only one sg, but is not right in case multi sgs
+in one transfer,because the tail data should be based on the last sg
+length instead of the whole transfer length. Move wml setting for DMA
+to the later place, thus, the next patch could get the right last sg
+length for wml setting. This patch is a preparation one, no any
+function change involved.
+
+Signed-off-by: Robin Gong <yibin.gong@nxp.com>
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-imx.c | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/spi/spi-imx.c b/drivers/spi/spi-imx.c
+index 5b6f3655c366..e2497e0c8f33 100644
+--- a/drivers/spi/spi-imx.c
++++ b/drivers/spi/spi-imx.c
+@@ -63,6 +63,7 @@ struct spi_imx_devtype_data {
+ 	void (*trigger)(struct spi_imx_data *);
+ 	int (*rx_available)(struct spi_imx_data *);
+ 	void (*reset)(struct spi_imx_data *);
++	void (*setup_wml)(struct spi_imx_data *);
+ 	void (*disable)(struct spi_imx_data *);
+ 	bool has_dmamode;
+ 	bool has_slavemode;
+@@ -583,6 +584,11 @@ static int mx51_ecspi_config(struct spi_device *spi)
+ 	else			/* SCLK is _very_ slow */
+ 		usleep_range(delay, delay + 10);
+ 
++	return 0;
++}
++
++static void mx51_setup_wml(struct spi_imx_data *spi_imx)
++{
+ 	/*
+ 	 * Configure the DMA register: setup the watermark
+ 	 * and enable DMA request.
+@@ -593,8 +599,6 @@ static int mx51_ecspi_config(struct spi_device *spi)
+ 		MX51_ECSPI_DMA_RXT_WML(spi_imx->wml) |
+ 		MX51_ECSPI_DMA_TEDEN | MX51_ECSPI_DMA_RXDEN |
+ 		MX51_ECSPI_DMA_RXTDEN, spi_imx->base + MX51_ECSPI_DMA);
+-
+-	return 0;
+ }
+ 
+ static int mx51_ecspi_rx_available(struct spi_imx_data *spi_imx)
+@@ -931,6 +935,7 @@ static struct spi_imx_devtype_data imx51_ecspi_devtype_data = {
+ 	.trigger = mx51_ecspi_trigger,
+ 	.rx_available = mx51_ecspi_rx_available,
+ 	.reset = mx51_ecspi_reset,
++	.setup_wml = mx51_setup_wml,
+ 	.fifo_size = 64,
+ 	.has_dmamode = true,
+ 	.dynamic_burst = true,
+@@ -1138,7 +1143,6 @@ static int spi_imx_setupxfer(struct spi_device *spi,
+ 				 struct spi_transfer *t)
+ {
+ 	struct spi_imx_data *spi_imx = spi_master_get_devdata(spi->master);
+-	int ret;
+ 
+ 	if (!t)
+ 		return 0;
+@@ -1179,12 +1183,6 @@ static int spi_imx_setupxfer(struct spi_device *spi,
+ 	else
+ 		spi_imx->usedma = 0;
+ 
+-	if (spi_imx->usedma) {
+-		ret = spi_imx_dma_configure(spi->master);
+-		if (ret)
+-			return ret;
+-	}
+-
+ 	if (is_imx53_ecspi(spi_imx) && spi_imx->slave_mode) {
+ 		spi_imx->rx = mx53_ecspi_rx_slave;
+ 		spi_imx->tx = mx53_ecspi_tx_slave;
+@@ -1289,6 +1287,13 @@ static int spi_imx_dma_transfer(struct spi_imx_data *spi_imx,
+ 	unsigned long timeout;
+ 	struct spi_master *master = spi_imx->bitbang.master;
+ 	struct sg_table *tx = &transfer->tx_sg, *rx = &transfer->rx_sg;
++	int ret;
++
++	ret = spi_imx_dma_configure(master);
++	if (ret)
++		return ret;
++
++	spi_imx->devtype_data->setup_wml(spi_imx);
+ 
+ 	/*
+ 	 * The TX DMA setup starts the transfer, so make sure RX is configured
+-- 
+2.33.0
+

--- a/0032-spi-imx-correct-wml-as-the-last-sg-length.patch
+++ b/0032-spi-imx-correct-wml-as-the-last-sg-length.patch
@@ -1,0 +1,101 @@
+From 40463edffd43b9d3aeeb8394a90c3d838787044e Mon Sep 17 00:00:00 2001
+From: Robin Gong <yibin.gong@nxp.com>
+Date: Wed, 10 Oct 2018 10:32:45 +0000
+Subject: [PATCH 2/5] spi: imx: correct wml as the last sg length
+
+Correct wml as the last rx sg length instead of the whole transfer
+length. Otherwise, mtd_stresstest will be failed as below:
+
+insmod mtd_stresstest.ko dev=0
+=================================================
+mtd_stresstest: MTD device: 0
+mtd_stresstest: not NAND flash, assume page size is 512 bytes.
+mtd_stresstest: MTD device size 4194304, eraseblock size 65536, page size 512, count of eraseblocks 64, pa0
+mtd_stresstest: doing operations
+mtd_stresstest: 0 operations done
+mtd_test: mtd_read from 1ff532, size 880
+mtd_test: mtd_read from 20c267, size 64998
+spi_master spi0: I/O Error in DMA RX
+m25p80 spi0.0: SPI transfer failed: -110
+spi_master spi0: failed to transfer one message from queue
+mtd_test: error: read failed at 0x20c267
+mtd_stresstest: error -110 occurred
+=================================================
+insmod: ERROR: could not insert module mtd_stresstest.ko: Connection timed out
+
+Signed-off-by: Robin Gong <yibin.gong@nxp.com>
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-imx.c | 29 +++++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/spi/spi-imx.c b/drivers/spi/spi-imx.c
+index e2497e0c8f33..685739d7d306 100644
+--- a/drivers/spi/spi-imx.c
++++ b/drivers/spi/spi-imx.c
+@@ -217,7 +217,6 @@ static bool spi_imx_can_dma(struct spi_master *master, struct spi_device *spi,
+ 			 struct spi_transfer *transfer)
+ {
+ 	struct spi_imx_data *spi_imx = spi_master_get_devdata(master);
+-	unsigned int bytes_per_word, i;
+ 
+ 	if (!master->dma_rx)
+ 		return false;
+@@ -225,14 +224,6 @@ static bool spi_imx_can_dma(struct spi_master *master, struct spi_device *spi,
+ 	if (spi_imx->slave_mode)
+ 		return false;
+ 
+-	bytes_per_word = spi_imx_bytes_per_word(transfer->bits_per_word);
+-
+-	for (i = spi_imx->devtype_data->fifo_size / 2; i > 0; i--) {
+-		if (!(transfer->len % (i * bytes_per_word)))
+-			break;
+-	}
+-
+-	spi_imx->wml = i;
+ 	spi_imx->dynamic_burst = 0;
+ 
+ 	return true;
+@@ -594,7 +585,7 @@ static void mx51_setup_wml(struct spi_imx_data *spi_imx)
+ 	 * and enable DMA request.
+ 	 */
+ 
+-	writel(MX51_ECSPI_DMA_RX_WML(spi_imx->wml) |
++	writel(MX51_ECSPI_DMA_RX_WML(spi_imx->wml - 1) |
+ 		MX51_ECSPI_DMA_TX_WML(spi_imx->wml) |
+ 		MX51_ECSPI_DMA_RXT_WML(spi_imx->wml) |
+ 		MX51_ECSPI_DMA_TEDEN | MX51_ECSPI_DMA_RXDEN |
+@@ -1287,12 +1278,30 @@ static int spi_imx_dma_transfer(struct spi_imx_data *spi_imx,
+ 	unsigned long timeout;
+ 	struct spi_master *master = spi_imx->bitbang.master;
+ 	struct sg_table *tx = &transfer->tx_sg, *rx = &transfer->rx_sg;
++	struct scatterlist *last_sg = sg_last(rx->sgl, rx->nents);
++	unsigned int bytes_per_word, i;
+ 	int ret;
+ 
++	/* Get the right burst length from the last sg to ensure no tail data */
++	bytes_per_word = spi_imx_bytes_per_word(transfer->bits_per_word);
++	for (i = spi_imx->devtype_data->fifo_size / 2; i > 0; i--) {
++		if (!(sg_dma_len(last_sg) % (i * bytes_per_word)))
++			break;
++	}
++	/* Use 1 as wml in case no available burst length got */
++	if (i == 0)
++		i = 1;
++
++	spi_imx->wml =  i;
++
+ 	ret = spi_imx_dma_configure(master);
+ 	if (ret)
+ 		return ret;
+ 
++	if (!spi_imx->devtype_data->setup_wml) {
++		dev_err(spi_imx->dev, "No setup_wml()?\n");
++		return -EINVAL;
++	}
+ 	spi_imx->devtype_data->setup_wml(spi_imx);
+ 
+ 	/*
+-- 
+2.33.0
+

--- a/0033-spi-imx-use-PIO-mode-if-size-is-small.patch
+++ b/0033-spi-imx-use-PIO-mode-if-size-is-small.patch
@@ -1,0 +1,31 @@
+From aa99d6114f384d33157f121d99d14d384d9bf11e Mon Sep 17 00:00:00 2001
+From: Robin Gong <yibin.gong@nxp.com>
+Date: Wed, 10 Oct 2018 10:32:48 +0000
+Subject: [PATCH 3/5] spi: imx: use PIO mode if size is small
+
+Use PIO mode instead if size is smaller than fifo size, since
+dma may be less efficient.
+
+Signed-off-by: Robin Gong <yibin.gong@nxp.com>
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-imx.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/spi/spi-imx.c b/drivers/spi/spi-imx.c
+index 685739d7d306..d8c375e42034 100644
+--- a/drivers/spi/spi-imx.c
++++ b/drivers/spi/spi-imx.c
+@@ -224,6 +224,9 @@ static bool spi_imx_can_dma(struct spi_master *master, struct spi_device *spi,
+ 	if (spi_imx->slave_mode)
+ 		return false;
+ 
++	if (transfer->len < spi_imx->devtype_data->fifo_size)
++		return false;
++
+ 	spi_imx->dynamic_burst = 0;
+ 
+ 	return true;
+-- 
+2.33.0
+

--- a/0034-Revert-ARM-dts-imx6q-Use-correct-SDMA-script-for-SPI.patch
+++ b/0034-Revert-ARM-dts-imx6q-Use-correct-SDMA-script-for-SPI.patch
@@ -1,0 +1,42 @@
+From bddbc0215df435a5e2b8943406430a1a5a594c9d Mon Sep 17 00:00:00 2001
+From: Robin Gong <yibin.gong@nxp.com>
+Date: Wed, 14 Jul 2021 18:20:41 +0800
+Subject: [PATCH 4/5] Revert "ARM: dts: imx6q: Use correct SDMA script for SPI5
+ core"
+
+  There are two ways for SDMA accessing SPBA devices: one is SDMA->AIPS
+->SPBA(masterA port), another is SDMA->SPBA(masterC port). Please refer
+to the 'Figure 58-1. i.MX 6Dual/6Quad SPBA connectivity' of i.mx6DQ
+Reference Manual. SDMA provide the corresponding app_2_mcu/mcu_2_app and
+shp_2_mcu/mcu_2_shp script for such two options. So both AIPS and SPBA
+scripts should keep the same behaviour, the issue only caught in AIPS
+script sounds not solide.
+  The issue is more likely as the ecspi errata
+ERR009165(http://www.nxp.com/docs/en/errata/IMX6DQCE.pdf):
+eCSPI: TXFIFO empty flag glitch can cause the current FIFO transfer to
+       be sent twice
+So revert commit 'df07101e1c4a' firstly.
+
+Signed-off-by: Robin Gong <yibin.gong@nxp.com>
+Acked-by: Sascha Hauer <s.hauer@pengutronix.de>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ arch/arm/boot/dts/imx6q.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/imx6q.dtsi b/arch/arm/boot/dts/imx6q.dtsi
+index 01afef23efd9..19657834b642 100644
+--- a/arch/arm/boot/dts/imx6q.dtsi
++++ b/arch/arm/boot/dts/imx6q.dtsi
+@@ -172,7 +172,7 @@
+ 					clocks = <&clks IMX6Q_CLK_ECSPI5>,
+ 						 <&clks IMX6Q_CLK_ECSPI5>;
+ 					clock-names = "ipg", "per";
+-					dmas = <&sdma 11 8 1>, <&sdma 12 8 2>;
++					dmas = <&sdma 11 7 1>, <&sdma 12 7 2>;
+ 					dma-names = "rx", "tx";
+ 					status = "disabled";
+ 				};
+-- 
+2.33.0
+

--- a/0035-Revert-ARM-dts-imx6-Use-correct-SDMA-script-for-SPI-.patch
+++ b/0035-Revert-ARM-dts-imx6-Use-correct-SDMA-script-for-SPI-.patch
@@ -1,0 +1,69 @@
+From d7260c277c053d43bbe8e5377c2c9c5227cae25e Mon Sep 17 00:00:00 2001
+From: Robin Gong <yibin.gong@nxp.com>
+Date: Wed, 14 Jul 2021 18:20:42 +0800
+Subject: [PATCH 5/5] Revert "ARM: dts: imx6: Use correct SDMA script for SPI
+ cores"
+
+There are two ways for SDMA accessing SPBA devices: one is SDMA->AIPS
+->SPBA(masterA port), another is SDMA->SPBA(masterC port). Please refer
+to the 'Figure 58-1. i.MX 6Dual/6Quad SPBA connectivity' of i.mx6DQ
+Reference Manual. SDMA provide the corresponding app_2_mcu/mcu_2_app and
+shp_2_mcu/mcu_2_shp script for such two options. So both AIPS and SPBA
+scripts should keep the same behaviour, the issue only caught in AIPS
+script sounds not solide.
+The issue is more likely as the ecspi errata
+ERR009165(http://www.nxp.com/docs/en/errata/IMX6DQCE.pdf):
+eCSPI: TXFIFO empty flag glitch can cause the current FIFO transfer to
+           be sent twice
+So revert commit 'dd4b487b32a3' firstly.
+
+Signed-off-by: Robin Gong <yibin.gong@nxp.com>
+Acked-by: Sascha Hauer <s.hauer@pengutronix.de>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ arch/arm/boot/dts/imx6qdl.dtsi | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/boot/dts/imx6qdl.dtsi b/arch/arm/boot/dts/imx6qdl.dtsi
+index 802cfa4f1137..6fc47271a2f5 100644
+--- a/arch/arm/boot/dts/imx6qdl.dtsi
++++ b/arch/arm/boot/dts/imx6qdl.dtsi
+@@ -329,7 +329,7 @@
+ 					clocks = <&clks IMX6QDL_CLK_ECSPI1>,
+ 						 <&clks IMX6QDL_CLK_ECSPI1>;
+ 					clock-names = "ipg", "per";
+-					dmas = <&sdma 3 8 1>, <&sdma 4 8 2>;
++					dmas = <&sdma 3 7 1>, <&sdma 4 7 2>;
+ 					dma-names = "rx", "tx";
+ 					status = "disabled";
+ 				};
+@@ -343,7 +343,7 @@
+ 					clocks = <&clks IMX6QDL_CLK_ECSPI2>,
+ 						 <&clks IMX6QDL_CLK_ECSPI2>;
+ 					clock-names = "ipg", "per";
+-					dmas = <&sdma 5 8 1>, <&sdma 6 8 2>;
++					dmas = <&sdma 5 7 1>, <&sdma 6 7 2>;
+ 					dma-names = "rx", "tx";
+ 					status = "disabled";
+ 				};
+@@ -357,7 +357,7 @@
+ 					clocks = <&clks IMX6QDL_CLK_ECSPI3>,
+ 						 <&clks IMX6QDL_CLK_ECSPI3>;
+ 					clock-names = "ipg", "per";
+-					dmas = <&sdma 7 8 1>, <&sdma 8 8 2>;
++					dmas = <&sdma 7 7 1>, <&sdma 8 7 2>;
+ 					dma-names = "rx", "tx";
+ 					status = "disabled";
+ 				};
+@@ -371,7 +371,7 @@
+ 					clocks = <&clks IMX6QDL_CLK_ECSPI4>,
+ 						 <&clks IMX6QDL_CLK_ECSPI4>;
+ 					clock-names = "ipg", "per";
+-					dmas = <&sdma 9 8 1>, <&sdma 10 8 2>;
++					dmas = <&sdma 9 7 1>, <&sdma 10 7 2>;
+ 					dma-names = "rx", "tx";
+ 					status = "disabled";
+ 				};
+-- 
+2.33.0
+


### PR DESCRIPTION
Without these patches, attempting to load a bitfile to the FPGA results in the following errors:

kosagi-fpga spi2.1: firmware: direct-loading firmware novena_fpga.bit
kosagi-fpga spi2.1: loading 1484797 bytes of firmware (in 65536-byte chunks)
spi_master spi2: I/O Error in DMA RX
kosagi-fpga spi2.1: SPI transfer failed: -110
spi_master spi2: failed to transfer one message from queue
kosagi-fpga: probe of spi2.1 failed with error -110